### PR TITLE
Fix tagging

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           # Prefix to query the tag by
           prefix: v
-          fallback: 1.0.0
+          fallback: v1.0.0
           
 
       - name: Log in to GitHub container registry

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -63,5 +63,5 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO }}:${{ env.TAG }}-${{ github.sha }} 
-            ghcr.io/${{ env.REPO }}:${{ env.TAG }}-v${{ steps.latest-tag.outputs.tag }}
+            ghcr.io/${{ env.REPO }}:${{ env.TAG }}-${{ steps.latest-tag.outputs.tag }}
           file: ./src/${{ matrix.dockerfile }}/Dockerfile


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-containers.yml` file, specifically in the `jobs:` section. The changes are mainly focused on modifying the versioning and tagging system for the Docker containers. 

* [`.github/workflows/build-containers.yml`](diffhunk://#diff-b24ff470084c5faea7d849d73c18f17c61316aa91c830fedda244a5c384f3097L44-R44): The `fallback` value under the `with:` section has been updated to include a 'v' prefix, changing from `1.0.0` to `v1.0.0`. This change ensures that the versioning is consistent across the project.
* [`.github/workflows/build-containers.yml`](diffhunk://#diff-b24ff470084c5faea7d849d73c18f17c61316aa91c830fedda244a5c384f3097L66-R66): The Docker container tagging system has been modified. The tag no longer includes a 'v' prefix before the output of the `latest-tag` step. This aligns the tagging with the updated versioning system.